### PR TITLE
Simplify pairing flow and clean up related config handling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,105 @@
+# Architecture
+
+A FastAPI app running on a Raspberry Pi that captures images and video, streams a
+low-res preview over a WebSocket relay, and uploads originals either to the ReLab
+backend or to S3-compatible storage. The RPi has no inbound network access, so all
+commands arrive over an outbound WebSocket.
+
+## Request flow
+
+```
+Browser / ReLab backend
+        │
+        ▼
+  (outbound WS)              (HTTP, LAN / loopback)
+        │                            │
+        ▼                            ▼
+  RelayService ──► FastAPI (app/main.py, app/router.py)
+                            │
+                            ▼
+               feature routers: camera / pairing / system / media / auth
+                            │
+                            ▼
+               feature services (app/<feature>/services/)
+                            │
+                            ▼
+                     AppRuntime container
+                            │
+                 ┌──────────┼──────────┐
+                 ▼          ▼          ▼
+           CameraManager  ImageSink  workers (below)
+```
+
+Feature modules own their own routers, services, and schemas. There is no
+centralized `api/` package — each module under [app/](app/) is self-contained.
+
+## AppRuntime
+
+[app/core/runtime.py](app/core/runtime.py) defines `AppRuntime`, a dataclass that
+holds every long-lived singleton (camera manager, preview pipeline, relay service,
+pairing service, upload queue worker, observability handle) plus the set of
+managed background tasks. One `AppRuntime` exists per process and is stored via
+`set_active_runtime` for code paths that cannot easily receive it as a parameter
+(e.g. pairing code that runs before any request).
+
+## Lifespan
+
+[app/core/bootstrap.py](app/core/bootstrap.py) + the FastAPI lifespan:
+
+1. Load `.env` settings ([app/core/settings.py](app/core/settings.py)).
+1. Apply any persisted relay credentials from
+   [app/pairing/services/credentials.py](app/pairing/services/credentials.py).
+1. Ensure a local API key exists (used for direct-Ethernet access).
+1. Construct `AppRuntime` and call `set_active_runtime`.
+1. Start background workers and the relay service as managed tasks.
+1. On shutdown, cancel every task in `background_tasks` / `recurring_tasks` and
+   close the camera / relay cleanly.
+
+## Background workers
+
+Owned and lifecycled by `AppRuntime`:
+
+- **ThermalGovernor** ([app/workers/thermal_governor.py](app/workers/thermal_governor.py)) —
+  reads SoC temperature, throttles or pauses streaming if the Pi is overheating.
+- **PreviewSleeper** ([app/workers/preview_sleeper.py](app/workers/preview_sleeper.py)) —
+  stops the lores preview encoder after `preview_hibernate_after_s` of relay
+  idleness; restarts it on the next command.
+- **PreviewThumbnailWorker** ([app/workers/preview_thumbnail.py](app/workers/preview_thumbnail.py)) —
+  keeps the setup page thumbnail fresh while the preview is active.
+- **UploadQueueWorker** ([app/upload/queue.py](app/upload/queue.py)) — drains the
+  file-backed retry queue for captures whose synchronous upload failed; entries
+  exhaust a 5-step exponential backoff before being dead-lettered to
+  `data/queue/dead/`.
+
+## Pairing
+
+If the device boots without relay credentials and `PAIRING_BACKEND_URL` is set,
+it enters pairing mode ([app/pairing/services/service.py](app/pairing/services/service.py)):
+generate a short code, register it, display it on `/setup`, poll until claimed,
+persist the returned credentials via
+[credentials.py](app/pairing/services/credentials.py), then hand control off to
+the relay service.
+
+## Relay
+
+[app/relay/service.py](app/relay/service.py) maintains a single outbound
+WebSocket to the backend with exponential reconnect. Inbound commands are
+dispatched to feature services under a concurrency cap
+(`RELAY_MAX_CONCURRENT_COMMANDS`). Authentication uses a signed device-assertion
+JWT built from the private key written during pairing.
+
+## Image sinks
+
+`ImageSink` ([app/image_sinks/base.py](app/image_sinks/base.py)) abstracts
+persistence: `BackendSink` POSTs to the ReLab backend, `S3Sink` uses
+`aioboto3`. The factory at [app/image_sinks/factory.py](app/image_sinks/factory.py)
+picks one based on `IMAGE_SINK` (`auto` infers from config). The upload queue is
+sink-agnostic — swapping sinks requires no changes to the queue or workers.
+
+## Configuration
+
+All configuration lives in [app/core/settings.py](app/core/settings.py) as a
+flat `Settings` (pydantic-settings v2) loaded from `.env`. Runtime-mutable state
+that must not live in the settings object (relay credentials, local API key) is
+kept on `RuntimeState` ([app/core/runtime_state.py](app/core/runtime_state.py))
+and accessed through `AppRuntime.runtime_state`.

--- a/app/backend/client.py
+++ b/app/backend/client.py
@@ -255,8 +255,12 @@ async def notify_self_unpair() -> None:
             )
         else:
             logger.warning(
-                "notify_self_unpair: backend returned HTTP %d — camera may remain registered",
+                "notify_self_unpair: backend returned HTTP %d — camera may remain registered "
+                "(url=%s server=%s body=%r)",
                 response.status_code,
+                response.request.url,
+                response.headers.get("server", "?"),
+                response.text[:500],
                 extra=build_log_extra(),
             )
     except httpx.HTTPError as exc:

--- a/app/core/bootstrap.py
+++ b/app/core/bootstrap.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 
 from app.core.runtime_state import RuntimeState
 from app.core.settings import IMAGE_SINK_AUTO, IMAGE_SINK_BACKEND, IMAGE_SINK_S3, Settings, settings
-from app.pairing.services.service import _CREDENTIALS_FILE, load_relay_credentials
+from app.pairing.services.credentials import _CREDENTIALS_FILE, load_relay_credentials
 
 logger = logging.getLogger(__name__)
 

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -81,7 +81,7 @@ class Settings(BaseSettings):
 
     # Image sink selection. ``auto`` infers from what's configured:
     # ``pairing_backend_url`` → backend, ``s3_endpoint_url`` → s3, nothing → error.
-    image_sink: Literal["backend", "s3", "auto"] = "auto"
+    image_sink: Literal["backend", "s3", "auto"] = IMAGE_SINK_AUTO
     # S3-compatible sink config (required when image_sink=s3 or when auto-
     # inferred from S3_ENDPOINT_URL). Works with MinIO, B2, R2, Wasabi, AWS S3.
     s3_endpoint_url: str = ""

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -20,6 +20,27 @@ IMAGE_SINK_S3 = "s3"
 DEFAULT_PAIRING_BACKEND_URL = "https://api.cml-relab.org"
 
 
+def _parse_list_env(v: object) -> list[str]:
+    """Accept a JSON array, comma-separated string, or empty value.
+
+    Falls back to comma-splitting on JSON decode errors so common .env
+    mistakes (e.g. ``[KEY]`` as unquoted JSON) still yield a useful list
+    rather than a cryptic ``JSONDecodeError`` at startup.
+    """
+    if isinstance(v, list):
+        return cast("list[str]", v)
+    if not isinstance(v, str):
+        return cast("list[str]", list(v)) if isinstance(v, Iterable) else []
+    stripped = v.strip()
+    if not stripped:
+        return []
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return [k.strip().strip("\"'") for k in stripped.strip("[]").split(",") if k.strip()]
+    return cast("list[str]", [parsed] if not isinstance(parsed, list) else parsed)
+
+
 class Settings(BaseSettings):
     """Settings class to store all the configurations for the app."""
 
@@ -101,19 +122,7 @@ class Settings(BaseSettings):
     @field_validator("local_allowed_origins", mode="before")
     @classmethod
     def _parse_local_origins(cls, v: object) -> list[str]:
-        """Accept a JSON array, comma-separated string, or empty value."""
-        if isinstance(v, list):
-            return cast("list[str]", v)
-        if not isinstance(v, str):
-            return cast("list[str]", list(v)) if isinstance(v, Iterable) else []
-        stripped = v.strip()
-        if not stripped:
-            return []
-        try:
-            parsed = json.loads(stripped)
-        except json.JSONDecodeError:
-            return [k.strip().strip("\"'") for k in stripped.strip("[]").split(",") if k.strip()]
-        return cast("list[str]", [parsed] if not isinstance(parsed, list) else parsed)
+        return _parse_list_env(v)
 
     # WebSocket relay (auto-enabled when all three fields are set)
     relay_backend_url: str = ""  # wss://your-backend/plugins/rpi-cam/ws/connect
@@ -170,24 +179,7 @@ class Settings(BaseSettings):
     @field_validator("authorized_api_keys", mode="before")
     @classmethod
     def _parse_api_keys(cls, v: object) -> list[str]:
-        """Accept a JSON array, a comma-separated string, or an empty value.
-
-        Handles common .env mistakes such as ``[KEY]`` (unquoted JSON string)
-        by falling back to comma-splitting so the app still starts with a
-        meaningful error rather than a cryptic JSONDecodeError.
-        """
-        if isinstance(v, list):
-            return cast("list[str]", v)
-        if not isinstance(v, str):
-            return cast("list[str]", list(v)) if isinstance(v, Iterable) else []
-        stripped = v.strip()
-        if not stripped:
-            return []
-        try:
-            parsed = json.loads(stripped)
-        except json.JSONDecodeError:
-            return [k.strip().strip("\"'") for k in stripped.strip("[]").split(",") if k.strip()]
-        return cast("list[str]", [parsed] if not isinstance(parsed, list) else parsed)
+        return _parse_list_env(v)
 
     @field_validator("debug", mode="before")
     @classmethod

--- a/app/pairing/routers/setup.py
+++ b/app/pairing/routers/setup.py
@@ -7,7 +7,7 @@ import logging
 
 import httpx
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, Response
 
 from app.backend.client import notify_self_unpair
 from app.core.bootstrap import clear_runtime_relay_credentials
@@ -81,6 +81,19 @@ async def setup_page(request: Request) -> HTMLResponse:
             "lan_ips": lan_ips,
             "pairing_backend_reachable": pairing_backend_reachable,
         },
+    )
+
+
+@router.get("/pairing/state")
+async def pairing_state(request: Request) -> JSONResponse:
+    """Return the current pairing state for client-side polling by the setup page."""
+    runtime = get_request_runtime(request)
+    state = runtime.pairing_service.get_state()
+    return JSONResponse(
+        {
+            "status": state.status,
+            "relay_enabled": runtime.runtime_state.relay_enabled,
+        }
     )
 
 

--- a/app/pairing/services/credentials.py
+++ b/app/pairing/services/credentials.py
@@ -1,0 +1,87 @@
+"""On-disk relay credentials file I/O.
+
+Extracted from ``service.py`` so ``app.core.bootstrap`` can import the
+credentials loader without pulling in the pairing orchestration module
+(which in turn needs bootstrap helpers) — breaking the previous
+startup-time import cycle.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _get_credentials_file() -> Path:
+    """Return the path to the relay credentials file.
+
+    Respects ``RELAB_CREDENTIALS_FILE`` if set; otherwise falls back to
+    ``~/.config/relab/relay_credentials.json`` (XDG-style).
+    """
+    if env_path := os.getenv("RELAB_CREDENTIALS_FILE"):
+        return Path(env_path)
+    return Path.home() / ".config" / "relab" / "relay_credentials.json"
+
+
+_CREDENTIALS_FILE = _get_credentials_file()
+
+
+def save_relay_credentials(
+    relay_backend_url: str,
+    camera_id: str,
+    relay_auth_scheme: str,
+    key_id: str,
+    private_key_pem: str,
+) -> None:
+    """Persist relay credentials atomically to the JSON credentials file.
+
+    Writes via a temp file + ``Path.replace`` so a power loss mid-write
+    cannot leave a truncated credentials file behind.
+    """
+    data = {
+        "relay_backend_url": relay_backend_url,
+        "relay_camera_id": camera_id,
+        "relay_auth_scheme": relay_auth_scheme,
+        "relay_key_id": key_id,
+        "relay_private_key_pem": private_key_pem,
+    }
+    _CREDENTIALS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w", dir=_CREDENTIALS_FILE.parent, delete=False, suffix=".tmp", encoding="utf-8"
+    ) as tmp:
+        tmp_path = tmp.name
+        tmp.write(json.dumps(data, indent=2))
+    try:
+        Path(tmp_path).replace(_CREDENTIALS_FILE)
+        _CREDENTIALS_FILE.chmod(0o600)
+    except OSError:
+        with suppress(OSError):
+            Path(tmp_path).unlink()
+        raise
+    logger.info("Relay credentials saved to %s", _CREDENTIALS_FILE)
+
+
+def load_relay_credentials() -> dict[str, str | bool] | None:
+    """Load relay credentials from the JSON file, if it exists."""
+    if not _CREDENTIALS_FILE.exists():
+        return None
+    try:
+        return json.loads(_CREDENTIALS_FILE.read_text())
+    except (json.JSONDecodeError, OSError):
+        logger.warning("Failed to read %s", _CREDENTIALS_FILE)
+        return None
+
+
+def delete_relay_credentials() -> None:
+    """Delete the on-disk credentials file, if present."""
+    try:
+        _CREDENTIALS_FILE.unlink(missing_ok=True)
+        logger.info("Relay credentials deleted from %s", _CREDENTIALS_FILE)
+    except OSError as exc:
+        logger.warning("Failed to delete relay credentials file: %s", exc)

--- a/app/pairing/services/service.py
+++ b/app/pairing/services/service.py
@@ -132,13 +132,13 @@ class PairingService:
                     return
                 except httpx.HTTPStatusError as exc:
                     _log_pairing_http_status_error(exc)
-                    logger.exception("Pairing cycle failed | retry_in_s=%.0f", retry_delay)
+                    logger.info("Pairing cycle retrying in %.0fs", retry_delay)
                     _clear_transient_pairing_state(self.state, status="error", error="Pairing failed — retrying…")
                     await asyncio.sleep(retry_delay)
                     retry_delay = min(retry_delay * 2, max_retry_delay)
                 except httpx.ConnectError as exc:
                     _log_pairing_connect_error(exc, base)
-                    logger.exception("Pairing cycle failed | retry_in_s=%.0f", retry_delay)
+                    logger.info("Pairing cycle retrying in %.0fs", retry_delay)
                     _clear_transient_pairing_state(
                         self.state, status="error", error="Pairing backend unreachable — retrying…"
                     )
@@ -304,6 +304,18 @@ def _log_pairing_http_status_error(exc: httpx.HTTPStatusError) -> None:
     """Log actionable guidance for backend rejections during pairing."""
     response = exc.response
     request = exc.request
+
+    # 5xx = the backend (or a gateway in front of it) is broken. These are
+    # transient and the body is usually a generic HTML error page from the
+    # gateway (Cloudflare, nginx) — logging it just adds noise.
+    if 500 <= response.status_code < 600:
+        logger.warning(
+            "Pairing backend %s returned HTTP %s — will retry.",
+            request.url,
+            response.status_code,
+        )
+        return
+
     body_snippet = response.text.strip().replace("\n", " ")
     if len(body_snippet) > 160:
         body_snippet = f"{body_snippet[:157]}..."

--- a/app/pairing/services/service.py
+++ b/app/pairing/services/service.py
@@ -12,12 +12,9 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import json as json_mod
 import logging
-import os
 import secrets
 import socket
-import tempfile
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -29,11 +26,24 @@ import httpx
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 
+from app.core.bootstrap import set_runtime_relay_credentials
 from app.core.runtime_context import get_active_runtime
 from app.core.settings import settings as app_settings
 from app.observability.logging import build_log_extra
 from app.pairing.services.client import PairingClient
+from app.pairing.services.credentials import (
+    _CREDENTIALS_FILE,
+    delete_relay_credentials,
+    load_relay_credentials,
+    save_relay_credentials,
+)
 from relab_rpi_cam_models import PairingClaimedBootstrap, PairingStatus, RelayAuthScheme
+
+__all__ = [
+    "_CREDENTIALS_FILE",
+    "delete_relay_credentials",
+    "load_relay_credentials",
+]
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
@@ -41,19 +51,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _get_credentials_file() -> Path:
-    """Get the path to the relay credentials file.
-
-    Respects env var RELAB_CREDENTIALS_FILE if set, otherwise uses:
-    ~/.config/relab/relay_credentials.json (following XDG Base Directory Spec)
-    """
-    if env_path := os.getenv("RELAB_CREDENTIALS_FILE"):
-        return Path(env_path)
-    config_dir = Path.home() / ".config" / "relab"
-    return config_dir / "relay_credentials.json"
-
-
-_CREDENTIALS_FILE = _get_credentials_file()
 _CODE_LENGTH = 3  # token_hex(3) → 6 hex chars
 PAIRING_CODE_TTL_SECONDS = 10 * 60
 
@@ -443,17 +440,13 @@ async def _complete_pairing_state(
     state.status = STATUS_PAIRED
     _clear_active_pairing_code(state)
 
-    _save_relay_credentials(
+    save_relay_credentials(
         relay_backend_url=relay_backend_url,
         camera_id=camera_id,
         relay_auth_scheme=relay_auth_scheme,
         key_id=key_id,
         private_key_pem=private_key_pem,
     )
-    # Local import: bootstrap imports _CREDENTIALS_FILE from this module, so a
-    # top-level import would create a circular dependency at startup.
-    from app.core.bootstrap import set_runtime_relay_credentials  # noqa: PLC0415
-
     set_runtime_relay_credentials(
         get_active_runtime().runtime_state,
         relay_backend_url=relay_backend_url,
@@ -497,67 +490,3 @@ def _private_key_pem(private_key: ec.EllipticCurvePrivateKey) -> str:
         format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
     ).decode("ascii")
-
-
-def _save_relay_credentials(
-    relay_backend_url: str,
-    camera_id: str,
-    relay_auth_scheme: str,
-    key_id: str,
-    private_key_pem: str,
-) -> None:
-    """Persist relay credentials to a separate JSON file (not .env).
-
-    This avoids corrupting the user's .env which may contain comments,
-    quotes, or other settings. The config loads these on next boot.
-    Writes atomically to prevent corruption on power loss.
-    Ensures the credentials directory exists before writing.
-    """
-    data = {
-        "relay_backend_url": relay_backend_url,
-        "relay_camera_id": camera_id,
-        "relay_auth_scheme": relay_auth_scheme,
-        "relay_key_id": key_id,
-        "relay_private_key_pem": private_key_pem,
-    }
-    # Ensure the directory exists
-    _CREDENTIALS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    # Write to a temp file first, then atomically replace
-    with tempfile.NamedTemporaryFile(
-        mode="w", dir=_CREDENTIALS_FILE.parent, delete=False, suffix=".tmp", encoding="utf-8"
-    ) as tmp:
-        tmp_path = tmp.name
-        tmp.write(json_mod.dumps(data, indent=2))
-    try:
-        Path(tmp_path).replace(_CREDENTIALS_FILE)
-        _CREDENTIALS_FILE.chmod(0o600)
-    except OSError:
-        # Clean up temp file if replace fails
-        with suppress(OSError):
-            Path(tmp_path).unlink()
-        raise
-    logger.info("Relay credentials saved to %s", _CREDENTIALS_FILE)
-
-
-def load_relay_credentials() -> dict[str, str | bool] | None:
-    """Load relay credentials from the JSON file, if it exists."""
-    if not _CREDENTIALS_FILE.exists():
-        return None
-    try:
-        return json_mod.loads(_CREDENTIALS_FILE.read_text())
-    except (json_mod.JSONDecodeError, OSError):
-        logger.warning("Failed to read %s", _CREDENTIALS_FILE)
-        return None
-
-
-def delete_relay_credentials() -> None:
-    """Delete the on-disk credentials file.
-
-    Does not touch runtime settings (relay_backend_url etc.) — call
-    ``clear_runtime_relay_credentials()`` separately for that.
-    """
-    try:
-        _CREDENTIALS_FILE.unlink(missing_ok=True)
-        logger.info("Relay credentials deleted from %s", _CREDENTIALS_FILE)
-    except OSError as exc:
-        logger.warning("Failed to delete relay credentials file: %s", exc)

--- a/app/templates/setup.html
+++ b/app/templates/setup.html
@@ -246,6 +246,42 @@
     window.setInterval(tick, 1000);
   });
 </script>
+<script>
+  // Poll the pairing state so the page auto-reloads when the pair or unpair
+  // finishes server-side (no manual refresh needed).
+  document.addEventListener("DOMContentLoaded", () => {
+    const initialRelayEnabled = {{ "true" if relay_enabled else "false" }};
+    const initialStatus = {{ pairing.status | tojson }};
+
+    let reloading = false;
+    const reload = () => {
+      if (reloading) return;
+      reloading = true;
+      window.location.reload();
+    };
+
+    const poll = async () => {
+      if (reloading) return;
+      try {
+        const resp = await fetch("/pairing/state", { cache: "no-store" });
+        if (!resp.ok) return;
+        const data = await resp.json();
+        if (data.relay_enabled !== initialRelayEnabled) {
+          reload();
+          return;
+        }
+        if (data.status !== initialStatus) {
+          reload();
+        }
+      } catch {
+        // Network blip — keep polling.
+      }
+    };
+
+    const intervalId = window.setInterval(poll, 2000);
+    window.addEventListener("beforeunload", () => window.clearInterval(intervalId));
+  });
+</script>
 {% endblock %}
 
 {% block body %}

--- a/app/upload/queue.py
+++ b/app/upload/queue.py
@@ -87,15 +87,15 @@ class UploadQueue:
         await asyncio.to_thread(shutil.move, str(image_path), str(target_image))
 
         now = datetime.now(UTC)
-        entry_data = {
-            "image_id": image_id,
-            "filename": filename,
-            "capture_metadata": dict(capture_metadata),
-            "upload_metadata": dict(upload_metadata),
-            "attempts": 0,
-            "next_attempt_at": now.isoformat(),
-        }
-        await asyncio.to_thread(target_metadata.write_text, json.dumps(entry_data, indent=2))
+        await self._persist_metadata(
+            target_metadata,
+            image_id=image_id,
+            filename=filename,
+            capture_metadata=capture_metadata,
+            upload_metadata=upload_metadata,
+            attempts=0,
+            next_attempt_at=now,
+        )
 
         logger.info("Enqueued capture %s for backend retry", image_id, extra=build_log_extra())
         return QueuedCapture(

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -73,7 +73,6 @@ TRACEBACK_TEXT = "Traceback"
 # Image sink / MediaMTX test literals
 IMAGE_SINK_BACKEND = "backend"
 IMAGE_SINK_S3 = "s3"
-IMAGE_SINK_AUTO = "auto"
 DEFAULT_S3_REGION = "us-east-1"
 S3_BUCKET_NAME = "rpi-cam"
 S3_OBJECT_KEY = "rpi-cam/42/abc123.jpg"

--- a/tests/integration/test_setup.py
+++ b/tests/integration/test_setup.py
@@ -240,6 +240,34 @@ class TestSetupPage:
         assert SETUP_LOCAL_DNS_SUFFIX not in resp.text
 
 
+class TestPairingState:
+    """Tests for GET /pairing/state."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_runtime(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        runtime = AppRuntime()
+        runtime.pairing_service.state.status = "waiting"
+        monkeypatch.setattr(setup_router, "get_request_runtime", lambda _request: runtime)
+        self._runtime = runtime
+
+    async def test_returns_current_state(self, unauthed_client: AsyncClient) -> None:
+        resp = await unauthed_client.get("/pairing/state")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "waiting", "relay_enabled": False}
+
+    async def test_reflects_paired_state(self, unauthed_client: AsyncClient) -> None:
+        self._runtime.pairing_service.state.status = "paired"
+        self._runtime.runtime_state.set_relay_credentials(
+            relay_backend_url=EXAMPLE_RELAY_BACKEND_URL,
+            relay_camera_id="00000000-0000-0000-0000-000000000001",
+            relay_auth_scheme="device_assertion",
+            relay_key_id="kid-1",
+            relay_private_key_pem="pem",
+        )
+        resp = await unauthed_client.get("/pairing/state")
+        assert resp.json() == {"status": "paired", "relay_enabled": True}
+
+
 class TestUnpair:
     """Tests for DELETE /pairing."""
 

--- a/tests/integration/test_setup.py
+++ b/tests/integration/test_setup.py
@@ -251,11 +251,13 @@ class TestPairingState:
         self._runtime = runtime
 
     async def test_returns_current_state(self, unauthed_client: AsyncClient) -> None:
+        """Endpoint should return the current pairing state from the runtime."""
         resp = await unauthed_client.get("/pairing/state")
         assert resp.status_code == 200
         assert resp.json() == {"status": "waiting", "relay_enabled": False}
 
     async def test_reflects_paired_state(self, unauthed_client: AsyncClient) -> None:
+        """When the pairing service reports paired, the endpoint should reflect that."""
         self._runtime.pairing_service.state.status = "paired"
         self._runtime.runtime_state.set_relay_credentials(
             relay_backend_url=EXAMPLE_RELAY_BACKEND_URL,

--- a/tests/unit/pairing/test_flow.py
+++ b/tests/unit/pairing/test_flow.py
@@ -50,6 +50,8 @@ PAIRING_UNREACHABLE_ERROR = "Pairing backend unreachable — retrying…"
 PAIRING_RETRYING_ERROR = "Pairing failed — retrying…"
 PAIRING_READ_WARNING = "Failed to read"
 PAIRING_DELETE_WARNING = "Failed to delete relay credentials file"
+HTTP_502 = "HTTP 502"
+HTML_DOCTYPE_TAG = "<!DOCTYPE html>"
 
 
 class FakeResponse:
@@ -215,7 +217,7 @@ class TestPairingHelpers:
         bad_gateway = httpx.HTTPStatusError(
             "bad",
             request=request,
-            response=httpx.Response(502, request=request, text="<!DOCTYPE html>"),
+            response=httpx.Response(502, request=request, text=HTML_DOCTYPE_TAG),
         )
 
         with caplog.at_level(logging.WARNING):
@@ -223,9 +225,9 @@ class TestPairingHelpers:
             pairing_mod._log_pairing_http_status_error(bad_gateway)
 
         assert PAIRING_REGISTER_REFUSAL in caplog.text
-        assert "HTTP 502" in caplog.text
+        assert HTTP_502 in caplog.text
         # 5xx responses should not dump the gateway's HTML body.
-        assert "<!DOCTYPE html>" not in caplog.text
+        assert HTML_DOCTYPE_TAG not in caplog.text
 
     def test_log_pairing_http_status_error_truncates_long_response_body(
         self,

--- a/tests/unit/pairing/test_flow.py
+++ b/tests/unit/pairing/test_flow.py
@@ -205,37 +205,39 @@ class TestPairingHelpers:
         assert f"Pairing backend {EXAMPLE_BACKEND_URL} could not be reached." in caplog.text
 
     def test_log_pairing_http_status_error_variants(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Register-specific 403s and generic failures should both be logged."""
+        """Register-specific 403s and 5xx failures should both be logged."""
         request = httpx.Request("POST", f"{EXAMPLE_BACKEND_URL}/plugins/rpi-cam/pairing/register")
         forbidden = httpx.HTTPStatusError(
             "forbidden",
             request=request,
             response=httpx.Response(403, request=request, text="nope"),
         )
-        generic = httpx.HTTPStatusError(
+        bad_gateway = httpx.HTTPStatusError(
             "bad",
             request=request,
-            response=httpx.Response(500, request=request, text="boom"),
+            response=httpx.Response(502, request=request, text="<!DOCTYPE html>"),
         )
 
-        with caplog.at_level(logging.ERROR):
+        with caplog.at_level(logging.WARNING):
             pairing_mod._log_pairing_http_status_error(forbidden)
-            pairing_mod._log_pairing_http_status_error(generic)
+            pairing_mod._log_pairing_http_status_error(bad_gateway)
 
         assert PAIRING_REGISTER_REFUSAL in caplog.text
-        assert PAIRING_HTTP_500 in caplog.text
+        assert "HTTP 502" in caplog.text
+        # 5xx responses should not dump the gateway's HTML body.
+        assert "<!DOCTYPE html>" not in caplog.text
 
     def test_log_pairing_http_status_error_truncates_long_response_body(
         self,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Very long backend bodies should be trimmed in logs."""
+        """Very long 4xx backend bodies should be trimmed in logs."""
         request = httpx.Request("GET", f"{EXAMPLE_BACKEND_URL}/plugins/rpi-cam/pairing/poll")
         long_body = "x" * 300
         error = httpx.HTTPStatusError(
             "bad",
             request=request,
-            response=httpx.Response(500, request=request, text=long_body),
+            response=httpx.Response(400, request=request, text=long_body),
         )
 
         with caplog.at_level(logging.ERROR):

--- a/tests/unit/pairing/test_flow.py
+++ b/tests/unit/pairing/test_flow.py
@@ -14,6 +14,7 @@ import pytest
 from app.auth.dependencies import reload_authorized_hashes
 from app.core.runtime import AppRuntime, set_active_runtime
 from app.core.settings import settings
+from app.pairing.services import credentials as pairing_credentials
 from app.pairing.services import service as pairing_mod
 from tests.constants import (
     EXAMPLE_BACKEND_URL,
@@ -133,12 +134,12 @@ class TestPairingHelpers:
         override = tmp_path / "relay.json"
         monkeypatch.setenv("RELAB_CREDENTIALS_FILE", str(override))
 
-        assert pairing_mod._get_credentials_file() == override
+        assert pairing_credentials._get_credentials_file() == override
 
     def test_get_credentials_file_falls_back_to_xdg_style_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Without an override, pairing should use the default config-home location."""
         monkeypatch.delenv("RELAB_CREDENTIALS_FILE", raising=False)
-        assert str(pairing_mod._get_credentials_file()).endswith(".config/relab/relay_credentials.json")
+        assert str(pairing_credentials._get_credentials_file()).endswith(".config/relab/relay_credentials.json")
 
     def test_pairing_service_reset_and_get_state(self) -> None:
         """Pairing service should expose and reset its observable state."""
@@ -431,7 +432,7 @@ class TestPairingCycle:
         monkeypatch.setattr(settings, "pairing_backend_url", EXAMPLE_BACKEND_URL)
         monkeypatch.setattr(settings, "base_url", "http://127.0.0.1:8018/")
         monkeypatch.setattr(pairing_mod, "_lan_setup_url", lambda _port: None)
-        monkeypatch.setattr(pairing_mod, "_save_relay_credentials", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(pairing_mod, "save_relay_credentials", lambda *_args, **_kwargs: None)
         monkeypatch.setattr(pairing_mod.asyncio, "sleep", AsyncMock())
         client: Any = FakeClient(
             post_responses=[FakeResponse(409), FakeResponse(201)],
@@ -488,7 +489,7 @@ class TestPairingCycle:
         """Expired pairing codes should rotate cleanly and log the new ready code."""
         monkeypatch.setattr(settings, "pairing_backend_url", EXAMPLE_BACKEND_URL)
         monkeypatch.setattr(settings, "base_url", "https://camera.example/")
-        monkeypatch.setattr(pairing_mod, "_save_relay_credentials", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(pairing_mod, "save_relay_credentials", lambda *_args, **_kwargs: None)
         monkeypatch.setattr(pairing_mod.asyncio, "sleep", AsyncMock())
         service = pairing_mod.PairingService()
         client: Any = FakeClient(
@@ -530,7 +531,7 @@ class TestPairingCycle:
         """A timeout while registering should be retried before the pairing cycle gives up."""
         monkeypatch.setattr(settings, "pairing_backend_url", EXAMPLE_BACKEND_URL)
         monkeypatch.setattr(settings, "base_url", "https://camera.example/")
-        monkeypatch.setattr(pairing_mod, "_save_relay_credentials", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(pairing_mod, "save_relay_credentials", lambda *_args, **_kwargs: None)
         monkeypatch.setattr(pairing_mod.asyncio, "sleep", AsyncMock())
         service = pairing_mod.PairingService()
         client: Any = FakeClient(
@@ -572,7 +573,7 @@ class TestPairingCycle:
         """A timeout while polling should be treated as transient and retried in place."""
         monkeypatch.setattr(settings, "pairing_backend_url", EXAMPLE_BACKEND_URL)
         monkeypatch.setattr(settings, "base_url", "https://camera.example/")
-        monkeypatch.setattr(pairing_mod, "_save_relay_credentials", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(pairing_mod, "save_relay_credentials", lambda *_args, **_kwargs: None)
         monkeypatch.setattr(pairing_mod.asyncio, "sleep", AsyncMock())
         service = pairing_mod.PairingService()
         client: Any = FakeClient(
@@ -655,10 +656,10 @@ class TestPairingCycle:
     async def test_saves_and_loads_credentials(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that credentials are saved to and loaded from disk correctly."""
         creds_file = tmp_path / "relay_credentials.json"
-        monkeypatch.setattr(pairing_mod, "_CREDENTIALS_FILE", creds_file)
+        monkeypatch.setattr(pairing_credentials, "_CREDENTIALS_FILE", creds_file)
         private_key = pairing_mod._private_key_pem(pairing_mod._generate_private_key())
 
-        pairing_mod._save_relay_credentials(
+        pairing_credentials.save_relay_credentials(
             EXAMPLE_RELAY_BACKEND_URL,
             RELAY_CAMERA_ID,
             RELAY_AUTH_SCHEME,
@@ -686,7 +687,7 @@ class TestPairingCycle:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that missing credentials files return None."""
-        monkeypatch.setattr(pairing_mod, "_CREDENTIALS_FILE", tmp_path / "missing.json")
+        monkeypatch.setattr(pairing_credentials, "_CREDENTIALS_FILE", tmp_path / "missing.json")
         assert pairing_mod.load_relay_credentials() is None
 
     async def test_register_pairing_code_raises_after_three_timeouts(
@@ -728,7 +729,7 @@ class TestPairingCycle:
         on_paired = AsyncMock()
         monkeypatch.setattr(
             pairing_mod,
-            "_save_relay_credentials",
+            "save_relay_credentials",
             lambda **kwargs: saved.append(
                 (
                     str(kwargs["relay_backend_url"]),
@@ -774,7 +775,7 @@ class TestPairingCycle:
     ) -> None:
         """A failed replace should remove the temp file and re-raise."""
         creds_file = tmp_path / "relay_credentials.json"
-        monkeypatch.setattr(pairing_mod, "_CREDENTIALS_FILE", creds_file)
+        monkeypatch.setattr(pairing_credentials, "_CREDENTIALS_FILE", creds_file)
         observed_tmp_paths: list[Path] = []
         original_replace = Path.replace
 
@@ -786,7 +787,7 @@ class TestPairingCycle:
         monkeypatch.setattr(Path, "replace", _failing_replace)
 
         with pytest.raises(OSError, match=PAIRING_FAILURE_LOG):
-            pairing_mod._save_relay_credentials(
+            pairing_credentials.save_relay_credentials(
                 EXAMPLE_RELAY_BACKEND_URL,
                 RELAY_CAMERA_ID,
                 RELAY_AUTH_SCHEME,
@@ -807,7 +808,7 @@ class TestPairingCycle:
         """Unreadable credentials files should warn and return None."""
         creds_file = tmp_path / "relay_credentials.json"
         creds_file.write_text("{invalid")
-        monkeypatch.setattr(pairing_mod, "_CREDENTIALS_FILE", creds_file)
+        monkeypatch.setattr(pairing_credentials, "_CREDENTIALS_FILE", creds_file)
 
         with caplog.at_level(logging.WARNING):
             assert pairing_mod.load_relay_credentials() is None
@@ -823,7 +824,7 @@ class TestPairingCycle:
         """Delete failures should be logged without crashing the caller."""
         creds_file = tmp_path / "relay_credentials.json"
         creds_file.write_text("x")
-        monkeypatch.setattr(pairing_mod, "_CREDENTIALS_FILE", creds_file)
+        monkeypatch.setattr(pairing_credentials, "_CREDENTIALS_FILE", creds_file)
 
         def _boom(*_args: object, **_kwargs: object) -> None:
             raise OSError(PAIRING_FAILURE_LOG)


### PR DESCRIPTION
**Summary**
- refactor relay credential persistence into a dedicated module
- add setup page polling so pairing state updates without a manual refresh
- improve pairing retry/error logging
- clean up settings parsing and image sink constants
- update tests and supporting docs/config to match the new flow